### PR TITLE
Switch to light minimalist theme

### DIFF
--- a/frontend/src/shared/styles/colors.ts
+++ b/frontend/src/shared/styles/colors.ts
@@ -2,11 +2,11 @@ import { Goal } from '../../types/goals';
 
 export const getGoalColor = (goal: Goal): string => {
     const baseColors = {
-        directive: '#9370DB',  // purple
-        project: '#4682B4',    // steel blue
-        achievement: '#CD5C5C', // indian red
-        routine: '#DAA520',    // goldenrod
-        task: '#81c784'        // lighter green
+        directive: '#b39ddb',  // muted purple
+        project: '#90caf9',    // soft blue
+        achievement: '#f48fb1', // light red
+        routine: '#ffecb3',    // pale yellow
+        task: '#a5d6a7'        // pastel green
     };
 
     // If completed, return a muted/grayed out version of the color

--- a/frontend/src/shared/styles/global.css
+++ b/frontend/src/shared/styles/global.css
@@ -7,16 +7,16 @@
 
 body {
     font-family: Arial, sans-serif;
-    background-color: #0a1929;
-    color: #ffffff;
+    background-color: #fafafa;
+    color: #333;
     overflow-x: hidden;
     max-width: 100vw;
 }
 
 nav {
-    background-color: #101f33;
+    background-color: #ffffff;
     padding: 15px 30px;
-    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
 }
 
 nav ul {
@@ -46,17 +46,17 @@ main {
 }
 
 .dayview-container {
-    background-color: #101f33;
-    border: 1px solid #1e3a5f;
+    background-color: #ffffff;
+    border: 1px solid #ddd;
     border-radius: 8px;
     padding: 20px;
     max-width: 800px;
     margin: 20px auto;
-    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
+    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
 }
 
 .dayview-title {
     font-size: 1.5rem;
-    color: #ffffff;
+    color: #333;
     margin-bottom: 10px;
 }

--- a/frontend/src/shared/styles/theme.ts
+++ b/frontend/src/shared/styles/theme.ts
@@ -2,25 +2,28 @@ import { createTheme } from '@mui/material';
 
 export const theme = createTheme({
   palette: {
-    mode: 'dark',
+    mode: 'light',
     primary: {
-      main: '#2196f3',
-      light: '#64b5f6',
-      dark: '#1976d2',
-    },
-    secondary: {
-      main: '#90caf9',
-      light: '#bbdefb',
+      main: '#64b5f6',
+      light: '#90caf9',
       dark: '#42a5f5',
     },
+    secondary: {
+      main: '#ce93d8',
+      light: '#e1bee7',
+      dark: '#ab47bc',
+    },
     background: {
-      default: '#0a1929',
-      paper: '#101f33',
+      default: '#fafafa',
+      paper: '#ffffff',
     },
     text: {
-      primary: '#ffffff',
-      secondary: 'rgba(255, 255, 255, 0.7)',
+      primary: '#333333',
+      secondary: '#666666',
     },
+  },
+  typography: {
+    fontFamily: '"Roboto", "Helvetica", "Arial", sans-serif',
   },
   components: {
     MuiPaper: {
@@ -33,7 +36,7 @@ export const theme = createTheme({
     MuiAppBar: {
       styleOverrides: {
         root: {
-          backgroundColor: '#101f33',
+          backgroundColor: '#ffffff',
           backgroundImage: 'none',
         },
       },


### PR DESCRIPTION
## Summary
- update MUI theme palette and font family for a clean minimalist look
- lighten global layout styles
- use pastel colors for goal types

## Testing
- `npm run test:ci --prefix frontend` *(fails: react-scripts not found)*