### PR TITLE
Add Google OAuth login

### DIFF
--- a/backend/src/server/http_handler.rs
+++ b/backend/src/server/http_handler.rs
@@ -29,6 +29,7 @@ pub fn create_routes(graph: Graph, user_locks: UserLocks) -> Router {
     let auth_routes = Router::new()
         .route("/signup", post(handle_signup))
         .route("/signin", post(handle_signin))
+        .route("/google", post(handle_google_signin))
         .route("/validate", get(handle_validate_token));
 
     let goals_routes = Router::new()
@@ -95,6 +96,13 @@ async fn handle_signin(
     Json(payload): Json<auth::AuthPayload>,
 ) -> Result<impl IntoResponse, StatusCode> {
     auth::sign_in(graph, payload.username, payload.password).await
+}
+
+async fn handle_google_signin(
+    Extension(graph): Extension<Graph>,
+    Json(payload): Json<auth::GoogleAuthPayload>,
+) -> Result<impl IntoResponse, StatusCode> {
+    auth::google_sign_in(graph, payload.token).await
 }
 
 async fn handle_validate_token(

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -27,6 +27,7 @@
 </head>
 
 <body>
+  <script src="https://accounts.google.com/gsi/client" async defer></script>
   <noscript>You need to enable JavaScript to run this app.</noscript>
   <div id="root"></div>
   <!--

--- a/frontend/src/pages/signin/Signin.tsx
+++ b/frontend/src/pages/signin/Signin.tsx
@@ -5,7 +5,7 @@ import { useAuth } from "../../shared/contexts/AuthContext";
 
 
 const Signin: React.FC = () => {
-  const { login, isAuthenticated } = useAuth();
+  const { login, loginWithGoogle, isAuthenticated } = useAuth();
   const navigate = useNavigate();
   const location = useLocation();
   const [username, setUsername] = useState("");
@@ -13,12 +13,38 @@ const Signin: React.FC = () => {
   const [error, setError] = useState<string | null>(null);
   const [success, setSuccess] = useState<string | null>(null);
 
+  const handleGoogleCredential = async (response: any) => {
+    setError(null);
+    setSuccess(null);
+    try {
+      const message = await loginWithGoogle(response.credential);
+      setSuccess(message);
+      navigate("/calendar");
+    } catch (err: any) {
+      setError(err.message || "Google sign in failed");
+    }
+  };
+
   useEffect(() => {
     if (isAuthenticated) {
       const destination = location.state?.from || '/';
       navigate(destination, { replace: true });
     }
   }, [isAuthenticated, navigate, location]);
+
+  useEffect(() => {
+    const clientId = process.env.REACT_APP_GOOGLE_CLIENT_ID;
+    if ((window as any).google && clientId) {
+      (window as any).google.accounts.id.initialize({
+        client_id: clientId,
+        callback: handleGoogleCredential,
+      });
+      (window as any).google.accounts.id.renderButton(
+        document.getElementById("googleSignInDiv"),
+        { theme: "outline", size: "large" }
+      );
+    }
+  }, []);
 
   const handleSignin = async (event: React.FormEvent) => {
     event.preventDefault();
@@ -80,6 +106,7 @@ const Signin: React.FC = () => {
               Sign In
             </Button>
           </form>
+          <Box id="googleSignInDiv" sx={{ mt: 2 }} />
         </Paper>
       </Box>
     </Container>


### PR DESCRIPTION
## Summary
- integrate Google login script in HTML
- add Google OAuth login option in AuthContext
- render Google sign-in button in the Signin page
- verify Google tokens and create users server-side
- wire new Google auth route into backend

## Testing
- `cargo test --manifest-path backend/Cargo.toml`
- `CI=true npm test` *(fails: timezone and calendar tests)*